### PR TITLE
feat: Reduce batch size for training dataset

### DIFF
--- a/train.py
+++ b/train.py
@@ -14,7 +14,7 @@ optimizer_unet = nn.optim.Adam(nn.state.get_parameters(unet), lr=0.0002, b1=0.5,
 optimizer_discriminator = nn.optim.Adam(nn.state.get_parameters(discriminator), lr=0.0002, b1=0.5, b2=0.999)
 
 # Load dataset
-train_dataset, val_dataset = get_dataset(batch_size=32)
+train_dataset, val_dataset = get_dataset(batch_size=16)
 X_train, Y_train = train_dataset
 X_val, Y_val = val_dataset
 


### PR DESCRIPTION
The batch size for the training dataset has been reduced from 32 to 16.
This change is made to reduce the memory usage during training, which
can be beneficial for systems with limited GPU memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the batch size for training and validation datasets, which may affect training speed and memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->